### PR TITLE
Add PR build verification workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,4 +24,4 @@ jobs:
         with:
           name: PilotLight-x86
           path: |
-            **\\Win32\\Release\\PilotLight.exe
+            **/Release/PilotLight.exe

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -30,4 +30,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: PilotLight-x86
-          path: '**\\Win32\\Release\\PilotLight.exe'
+          path: '**/Release/PilotLight.exe'


### PR DESCRIPTION
## Summary\nAdd a PR-focused workflow that builds the Win32 Release whenever a Pull Request is opened or a cron/* branch is pushed. The job uploads the resulting PilotLight.exe artifact so reviewers and the 10am cron jobs can confirm the builds ran on windows-latest before merging.\n\n## Testing\n- No runtime tests beyond the workflow itself.